### PR TITLE
Implements DailyExchangeRatesBank for money conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ build-iPhoneSimulator/
 #
 # vendor/Pods/
 
+## VIM
+*.swp
+*~
+
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/
@@ -40,11 +44,9 @@ build-iPhoneSimulator/
 /vendor/bundle
 /lib/bundler/man/
 
-# for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+Gemfile.lock
+.ruby-version
+.ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+AllCops:
+  TargetRubyVersion: 2.6
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Metrics/BlockLength:
+  Exclude:
+    - !ruby/regexp /_spec\.rb$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# daily_exchange_rates_bank changelog
+
+## 1.0.0 (20.9.2019)
+
+* Initial gem release

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# daily_exchange_rates_bank
+# DailyExchangeRatesBank
+
+[![Codeship Status for gapfish/daily_exchange_rates_bank](https://app.codeship.com/projects/4d5d2f00-c367-0137-d12d-621d2c7e26d1/status?branch=master)](https://app.codeship.com/projects/366592)
+
 A bank for the money gem that determines exchange rates for any desired date.
+Missing exchange rates are fetched from exchangeratesapi.io
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+`gem 'daily_exchange_rates_bank'`
+
+and then execute:
+
+`$ bundle`
+
+Or install it yourself:
+
+`$ gem install daily_exchange_rates_bank`
+
+## Usage
+
+```ruby
+require 'daily_exchange_rates_bank'
+
+bank = DailyExchangeRatesBank.new
+Money.default_bank = bank
+
+Money.new(100, 'EUR').exchange_to('USD')  # => Money.new(109, 'USD')
+bank.get_rate('EUR', 'USD') # => 1.0935
+
+date = Date.new(2019, 7, 1)
+bank.exchange(100, 'EUR', 'USD', date) # => Money.new(113, 'USD')
+bank.exchange_with(Money.new(100, 'EUR'), 'USD', date) # => Money.new(113, 'USD')
+```
+
+If you are using the [money-rails](https://github.com/RubyMoney/money-rails)
+gem, you can set the default_bank in `config/initializers/money.rb`:
+
+```ruby
+MoneyRails.configure do |config|
+  config.default_bank = DailyExchangeRatesBank.new
+
+  # remaining config
+end
+```

--- a/daily_exchange_rates_bank.gemspec
+++ b/daily_exchange_rates_bank.gemspec
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name          = 'daily_exchange_rates_bank'
+  s.license       = 'gpl-3.0'
+  s.version       = '1.0.0'
+  s.date          = '2019-09-20'
+  s.summary       = 'A bank for the money gem that determines exchange rates '\
+    'for any desired date.'
+  s.description   = 'This gem supports money conversions with '\
+    'historic exchange rates. ' \
+    'Missing exchange rates are fetched from exchangeratesapi.io'
+  s.homepage      = 'https://github.com/gapfish/daily_exchange_rates_bank'
+  s.authors       = ['Robert Aschenbrenner']
+  s.email         = 'robert.aschenbrenner@gapfish.com'
+  s.files         = Dir.glob('lib/**/*') + %w[CHANGELOG.md LICENSE README.md]
+  s.require_path  = 'lib'
+
+  s.add_dependency 'money', '~> 6.13'
+
+  s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'rspec', '~> 3.8'
+  s.add_development_dependency 'rubocop', '~> 0.74.0'
+  s.add_development_dependency 'simplecov', '~> 0.17'
+  s.add_development_dependency 'webmock', '~> 3.7'
+end

--- a/lib/daily_exchange_rates_bank.rb
+++ b/lib/daily_exchange_rates_bank.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'money'
+require 'money/rates_store/store_with_date_support'
+require 'daily_exchange_rates_bank/exchange_rates_api_client'
+
+# Class for aiding in exchanging money between different currencies.
+class DailyExchangeRatesBank < Money::Bank::VariableExchange
+  SERIALIZER_DATE_SEPARATOR = '_ON_'
+
+  def initialize(store = Money::RatesStore::StoreWithDateSupport.new, &block)
+    super(store, &block)
+  end
+
+  def get_rate(from, to, date = nil)
+    store.get_rate(::Money::Currency.wrap(from).iso_code,
+                   ::Money::Currency.wrap(to).iso_code,
+                   date)
+  end
+
+  def set_rate(from, to, rate, date = nil)
+    store.add_rate(::Money::Currency.wrap(from).iso_code,
+                   ::Money::Currency.wrap(to).iso_code,
+                   rate,
+                   date)
+  end
+
+  def rates
+    store.each_rate.each_with_object({}) do |(from, to, rate, date), hash|
+      key = [from, to].join(SERIALIZER_SEPARATOR)
+      key = [key, date.to_s].join(SERIALIZER_DATE_SEPARATOR) if date
+      hash[key] = rate
+    end
+  end
+
+  def exchange(cents, from_currency, to_currency, date = nil)
+    exchange_with(Money.new(cents, from_currency), to_currency, date)
+  end
+
+  def exchange_with(from, to_currency, date = nil)
+    to_currency = ::Money::Currency.wrap(to_currency)
+    return from if from.currency == to_currency
+
+    rate = get_rate(from.currency, to_currency, date)
+
+    rate ||= rate_from_exchange_rates_api(from.currency, to_currency, date)
+
+    fractional = calculate_fractional(from, to_currency, rate)
+    Money.new(fractional, to_currency)
+  end
+
+  private
+
+  def rate_from_exchange_rates_api(from_currency, to_currency, date)
+    api_client = DailyExchangeRatesBank::ExchangeRatesApiClient.new
+    rates = api_client.exchange_rates(from: from_currency.iso_code,
+                                      to: [to_currency.iso_code],
+                                      date: (date || Date.today))
+    rate = rates[to_currency.iso_code]
+
+    set_rate(from_currency, to_currency, rate, date)
+
+    rate
+  end
+
+  def calculate_fractional(from, to_currency, rate)
+    BigDecimal(rate.to_s) * BigDecimal(from.fractional.to_s) / (
+      BigDecimal(from.currency.subunit_to_unit.to_s) /
+      BigDecimal(to_currency.subunit_to_unit.to_s)
+    )
+  end
+end

--- a/lib/daily_exchange_rates_bank/exchange_rates_api_client.rb
+++ b/lib/daily_exchange_rates_bank/exchange_rates_api_client.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+
+class DailyExchangeRatesBank < Money::Bank::VariableExchange
+  # Access exchangeratesapi.io to fetch historic exchange rates
+  class ExchangeRatesApiClient
+    def exchange_rates(from: 'EUR', to: %w[USD GBP CHF], date: Date.today)
+      uri = URI.parse('https://api.exchangeratesapi.io/')
+      uri.path = "/#{date}/"
+      uri.query = "base=#{from}&symbols=#{to.join(',')}"
+      json_response = uri.read
+      JSON.parse(json_response)['rates']
+    end
+  end
+end

--- a/lib/money/rates_store/store_with_date_support.rb
+++ b/lib/money/rates_store/store_with_date_support.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'date'
+
+class Money
+  module RatesStore
+    # Class for thread-safe storage of exchange rates per date.
+    class StoreWithDateSupport < Money::RatesStore::Memory
+      INDEX_DATE_SEPARATOR = '_ON_'
+
+      def add_rate(currency_iso_from, currency_iso_to, rate, date = nil)
+        transaction do
+          index[rate_key_for(currency_iso_from, currency_iso_to, date)] = rate
+        end
+      end
+
+      def get_rate(currency_iso_from, currency_iso_to, date = nil)
+        transaction do
+          index[rate_key_for(currency_iso_from, currency_iso_to, date)]
+        end
+      end
+
+      # Iterate over exchange rate tuples
+      #
+      # @yieldparam iso_from [String] Currency ISO string.
+      # @yieldparam iso_to [String] Currency ISO string.
+      # @yieldparam rate [String] Exchange rate.
+      # @yieldparam date [Date] Date of the exchange rate. Nil for current rate.
+      #
+      # @return [Enumerator]
+      # @example
+      #   store.each_rate do |iso_from, iso_to, rate, date|
+      #     puts [iso_from, iso_to, rate, date].join
+      #   end
+      def each_rate(&block)
+        enum = Enumerator.new do |yielder|
+          index.each do |key, rate|
+            iso_from, iso_to = key.split(Memory::INDEX_KEY_SEPARATOR)
+            iso_to, date = iso_to.split(INDEX_DATE_SEPARATOR)
+            date = Date.parse(date) if date
+            yielder.yield iso_from, iso_to, rate, date
+          end
+        end
+
+        block_given? ? enum.each(&block) : enum
+      end
+
+      private
+
+      def rate_key_for(currency_iso_from, currency_iso_to, date = nil)
+        key = [currency_iso_from, currency_iso_to].
+          join(Memory::INDEX_KEY_SEPARATOR)
+        key = [key, date.to_s].join(INDEX_DATE_SEPARATOR) if date
+        key.upcase
+      end
+    end
+  end
+end

--- a/spec/daily_exchange_rates_bank/exchange_rates_api_client_spec.rb
+++ b/spec/daily_exchange_rates_bank/exchange_rates_api_client_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'daily_exchange_rates_bank/exchange_rates_api_client'
+
+RSpec.describe DailyExchangeRatesBank::ExchangeRatesApiClient do
+  describe '#exchange_rates', :webmock do
+    it 'shows three select exchange rates of EUR by default' do
+      json_response = {
+        'rates' => {
+          'CHF' => 1.0934, 'USD' => 1.1003, 'GBP' => 0.89133
+        },
+        'base' => 'EUR',
+        'date' => '2019-09-11'
+      }.to_json
+      stub_request(:get, "https://api.exchangeratesapi.io/#{Date.today}/").
+        with(query: 'base=EUR&symbols=USD,GBP,CHF').
+        to_return(status: 200, body: json_response)
+
+      rates = described_class.new.exchange_rates
+      expect(rates).to eq(
+        'USD' => 1.1003,
+        'GBP' => 0.89133,
+        'CHF' => 1.0934
+      )
+    end
+  end
+end

--- a/spec/daily_exchange_rates_bank_spec.rb
+++ b/spec/daily_exchange_rates_bank_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DailyExchangeRatesBank do
+  let(:bank) { DailyExchangeRatesBank.new }
+
+  describe '#store' do
+    it 'defaults to memory store with date support' do
+      expect(bank.store).to be_a(Money::RatesStore::StoreWithDateSupport)
+    end
+  end
+
+  describe '#set_rate' do
+    it 'delegates to store#add_rate' do
+      expect(bank.store).to receive(:add_rate).with('CHF', 'EUR', 0.9, nil).
+        and_return(0.9)
+
+      expect(bank.set_rate('CHF', 'EUR', 0.9)).to eq 0.9
+    end
+
+    it 'passes on date parameter' do
+      date = Date.new(2019, 9, 20)
+      expect(bank.store).to receive(:add_rate).with('CHF', 'EUR', 0.9, date).
+        and_return(0.9)
+
+      expect(bank.set_rate('CHF', 'EUR', 0.9, date)).to eq 0.9
+    end
+  end
+
+  describe '#get_rate' do
+    it 'delegates to store#get_rate' do
+      expect(bank.store).to receive(:get_rate).with('CHF', 'EUR', nil).
+        and_return(0.9)
+
+      expect(bank.get_rate('CHF', 'EUR')).to eq 0.9
+    end
+
+    it 'passes on date parameter' do
+      date = Date.new(2019, 9, 20)
+      expect(bank.store).to receive(:get_rate).with('CHF', 'EUR', date).
+        and_return(0.8)
+
+      expect(bank.get_rate('CHF', 'EUR', date)).to eq 0.8
+    end
+  end
+
+  describe '#rates' do
+    it 'returns all defined rates from store' do
+      bank.store.add_rate('CHF', 'EUR', 0.9)
+      bank.store.add_rate('CHF', 'EUR', 0.91, '2019-09-19')
+      bank.store.add_rate('USD', 'EUR', 0.789, '2019-09-01')
+
+      expect(bank.rates).to eq('CHF_TO_EUR' => 0.9,
+                               'CHF_TO_EUR_ON_2019-09-19' => 0.91,
+                               'USD_TO_EUR_ON_2019-09-01' => 0.789)
+    end
+  end
+
+  describe '#exchange' do
+    it 'delegates to exchange_with' do
+      cents = rand(1000)
+      from_currency = 'CHF'
+      to_currency = 'EUR'
+      date = Date.new(2019, 9, 20)
+      expect(bank).to receive(:exchange_with).
+        with(Money.new(cents, from_currency), to_currency, date)
+
+      bank.exchange(cents, from_currency, to_currency, date)
+    end
+  end
+
+  describe '#exchange_with' do
+    context 'when exchange rate is in store' do
+      before do
+        bank.store.add_rate('CHF', 'EUR', 0.921)
+      end
+
+      it 'accepts string currency parameter' do
+        expect { bank.exchange_with(Money.new(100, 'CHF'), 'EUR') }.
+          to_not raise_exception
+      end
+
+      it 'accepts string currency parameter' do
+        expect do
+          bank.exchange_with(Money.new(100, 'CHF'), Money::Currency.wrap('EUR'))
+        end.to_not raise_error
+      end
+
+      it 'raises UnknownCurrency error when an unknown currency is passed' do
+        expect { bank.exchange_with(Money.new(100, 'EUR'), 'XYZ') }.
+          to raise_error(Money::Currency::UnknownCurrency)
+      end
+
+      it 'uses rate from store and truncates digits' do
+        expect(bank.exchange_with(Money.new(100, 'CHF'), 'EUR')).
+          to eq Money.new(92, 'EUR')
+      end
+
+      it 'considers differences in subunit-to-unit-ratios' do
+        bank.store.add_rate('EUR', 'JPY', 118.07)
+
+        expect(bank.exchange_with(Money.new(1000, 'EUR'), 'JPY')).
+          to eq Money.new(1181, 'JPY')
+      end
+
+      it 'supports exchange for specific dates' do
+        date = Date.new(2019, 9, 20)
+        bank.store.add_rate('CHF', 'EUR', 0.987, date)
+
+        expect(bank.exchange_with(Money.new(100, 'CHF'), 'EUR', date)).
+          to eq Money.new(99, 'EUR')
+      end
+    end
+
+    context 'when exchange rate is not in store' do
+      let(:api_client) do
+        instance_double(DailyExchangeRatesBank::ExchangeRatesApiClient)
+      end
+
+      it 'fetches exchange rate from exchangeratesapi.io and stores it' do
+        date = Date.new(2019, 9, 21)
+        expect(DailyExchangeRatesBank::ExchangeRatesApiClient).to receive(:new).
+          and_return(api_client)
+        expect(api_client).to receive(:exchange_rates).
+          with(from: 'CHF', to: ['EUR'], date: date).
+          and_return('EUR' => 0.9139097057)
+
+        expect(bank.exchange_with(Money.new(1000, 'CHF'), 'EUR', date)).
+          to eq Money.new(914, 'EUR')
+        expect(bank.get_rate('CHF', 'EUR', date)).to eq 0.9139097057
+      end
+
+      context 'without specified date' do
+        it 'fetches latest exchange rate' do
+          expect(DailyExchangeRatesBank::ExchangeRatesApiClient).
+            to receive(:new).
+            and_return(api_client)
+          expect(api_client).to receive(:exchange_rates).
+            with(from: 'EUR', to: ['USD'], date: Date.today).
+            and_return('USD' => 1.091234)
+
+          expect(bank.exchange_with(Money.new(100, 'EUR'), 'USD')).
+            to eq Money.new(109, 'USD')
+          expect(bank.get_rate('EUR', 'USD')).to eq 1.091234
+        end
+      end
+    end
+  end
+end

--- a/spec/money/rates_store/store_with_date_support_spec.rb
+++ b/spec/money/rates_store/store_with_date_support_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Money::RatesStore::StoreWithDateSupport do
+  let(:store) { described_class.new }
+
+  describe '#add_rate and #get_rate' do
+    it 'stores rate in memory' do
+      expect(store.add_rate('CHF', 'EUR', 0.9)).to eq 0.9
+      expect(store.add_rate('USD', 'EUR', 0.8)).to eq 0.8
+
+      expect(store.get_rate('CHF', 'EUR')).to eq 0.9
+      expect(store.get_rate('USD', 'EUR')).to eq 0.8
+    end
+
+    it 'supports date parameter' do
+      date = Date.parse('2019-09-19')
+      rate = 0.9115770283
+
+      expect(store.add_rate('CHF', 'EUR', rate, date)).to eq rate
+      expect(store.get_rate('CHF', 'EUR', date)).to eq rate
+    end
+  end
+
+  describe '#each_rate' do
+    it 'iterates over added rates' do
+      store.add_rate('CHF', 'EUR', 0.9, '2019-09-19')
+      store.add_rate('USD', 'EUR', 0.8, '2019-08-01')
+      store.add_rate('EUR', 'USD', 1.1)
+
+      expect(store.each_rate).to be_kind_of(Enumerator)
+
+      expect { |b| store.each_rate(&b) }.to yield_successive_args(
+        ['CHF', 'EUR', 0.9, Date.new(2019, 9, 19)],
+        ['USD', 'EUR', 0.8, Date.new(2019, 8, 1)],
+        ['EUR', 'USD', 1.1, nil]
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+require 'webmock/rspec'
+require 'daily_exchange_rates_bank'
+
+RSpec.configure do |c|
+  c.order = :random
+end


### PR DESCRIPTION
A specific date can be supplied to use a historic exchange rate.
Missing exchange rates are fetched from exchangeratesapi.io