### PR TITLE
Replace exchangeratesapi.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # daily_exchange_rates_bank changelog
 
-## 1.0.0 (20.9.2019)
+## 1.0.2 (22.04.2021)
+
+* Switch to api.frankfurter.app to fetch historic exchange rates
+
+## 1.0.1 (09.02.2021)
+
+* Loosen dependency on money gem version
+
+## 1.0.0 (20.09.2019)
 
 * Initial gem release

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Codeship Status for gapfish/daily_exchange_rates_bank](https://app.codeship.com/projects/4d5d2f00-c367-0137-d12d-621d2c7e26d1/status?branch=master)](https://app.codeship.com/projects/366592)
 
 A bank for the money gem that determines exchange rates for any desired date.
-Missing exchange rates are fetched from exchangeratesapi.io
+Missing exchange rates are fetched from api.frankfurter.app. This is
+configurable with the `RATES_API_URL` environment variable.
 
 ## Installation
 

--- a/daily_exchange_rates_bank.gemspec
+++ b/daily_exchange_rates_bank.gemspec
@@ -3,13 +3,12 @@
 Gem::Specification.new do |s|
   s.name          = 'daily_exchange_rates_bank'
   s.license       = 'GPL-3.0'
-  s.version       = '1.0.1'
-  s.date          = '2019-09-20'
+  s.version       = '1.0.2'
   s.summary       = 'A bank for the money gem that determines exchange rates '\
     'for any desired date.'
   s.description   = 'This gem supports money conversions with '\
     'historic exchange rates. ' \
-    'Missing exchange rates are fetched from exchangeratesapi.io'
+    'Missing exchange rates are fetched from api.frankfurter.app'
   s.homepage      = 'https://github.com/gapfish/daily_exchange_rates_bank'
   s.authors       = ['Robert Aschenbrenner']
   s.files         = Dir.glob('lib/**/*') + %w[CHANGELOG.md LICENSE README.md]

--- a/lib/daily_exchange_rates_bank/exchange_rates_api_client.rb
+++ b/lib/daily_exchange_rates_bank/exchange_rates_api_client.rb
@@ -3,10 +3,11 @@
 require 'open-uri'
 
 class DailyExchangeRatesBank < Money::Bank::VariableExchange
-  # Access exchangeratesapi.io to fetch historic exchange rates
+  # Access api.frankfurter.app to fetch historic exchange rates
   class ExchangeRatesApiClient
     def exchange_rates(from: 'EUR', to: %w[USD GBP CHF], date: Date.today)
-      uri = URI.parse('https://api.exchangeratesapi.io/')
+      api_url = ENV.fetch('RATES_API_URL', 'https://api.frankfurter.app/')
+      uri = URI.parse(api_url)
       uri.path = "/#{date}/"
       uri.query = "base=#{from}&symbols=#{to.join(',')}"
       json_response = uri.read

--- a/spec/daily_exchange_rates_bank/exchange_rates_api_client_spec.rb
+++ b/spec/daily_exchange_rates_bank/exchange_rates_api_client_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DailyExchangeRatesBank::ExchangeRatesApiClient do
         'base' => 'EUR',
         'date' => '2019-09-11'
       }.to_json
-      stub_request(:get, "https://api.exchangeratesapi.io/#{Date.today}/").
+      stub_request(:get, "https://api.frankfurter.app/#{Date.today}/").
         with(query: 'base=EUR&symbols=USD,GBP,CHF').
         to_return(status: 200, body: json_response)
 

--- a/spec/daily_exchange_rates_bank_spec.rb
+++ b/spec/daily_exchange_rates_bank_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe DailyExchangeRatesBank do
         instance_double(DailyExchangeRatesBank::ExchangeRatesApiClient)
       end
 
-      it 'fetches exchange rate from exchangeratesapi.io and stores it' do
+      it 'fetches exchange rate from api.frankfurter.app and stores it' do
         date = Date.new(2019, 9, 21)
         expect(DailyExchangeRatesBank::ExchangeRatesApiClient).to receive(:new).
           and_return(api_client)


### PR DESCRIPTION
The previously used exchangeratesapi.io has been bought and is not
publicly available anymore.
This changeset switches to the alternative api.frankfurter.app per
default. It also makes the url to use configurable, in case one might
decide to host it on his own.